### PR TITLE
Support deployment swap slots

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -49,6 +49,12 @@ variables:
   value: $[coalesce(variables['WebAppDomainName'], '')]
 - name: 'SafeWebAppCertName'
   value: $[coalesce(variables['WebAppCertName'], '')]
+- name: 'SafeWebAppSwapSlotName'
+  value: $[coalesce(variables['WebAppSwapSlotName'], '')]
+
+  # Deploy to the swap slot if defined
+- name: 'WebAppDeploySlotName'
+  value: $[coalesce(variables['SafeWebAppSwapSlotName'], variables['SafeWebAppSlotName'])]
 
 stages:
 - stage: 'BuildInfrastructure'
@@ -82,6 +88,7 @@ stages:
             webAppSkuName="$(WebAppSkuName)"; `
             webAppSkuCapacity=$(WebAppSkuCapacity); `
             webAppSlotName="$(SafeWebAppSlotName)"; `
+            webAppSwapSlotName="$(SafeWebAppSwapSlotName)"; `
             webAppDomainName="$(SafeWebAppDomainName)"; `
             webAppCertName="$(SafeWebAppCertName)" `
           }
@@ -231,6 +238,6 @@ stages:
               appType: 'webApp'
               deployToSlotOrASE: true
               resourceGroupName: '$(SafeAzureSharedResourceGroup)'
-              slotName: '$(SafeWebAppSlotName)'
+              slotName: '$(WebAppDeploySlotName)'
               package: '$(Pipeline.Workspace)/next/dist.zip'
               deploymentMethod: 'zipDeploy'

--- a/.azure/infra/app-service-config.bicep
+++ b/.azure/infra/app-service-config.bicep
@@ -24,6 +24,6 @@ resource webAppSlotConfig 'Microsoft.Web/sites/slots/config@2020-12-01' = if(isS
 }
 
 resource webAppSwapSlotConfig 'Microsoft.Web/sites/slots/config@2020-12-01' = if(hasSwapSlot) {
-  name: '${appServiceName}/${swapSlotName}/appsettings'
+  name: '${appServiceName}/${hasSwapSlot ? swapSlotName : 'undefined'}/appsettings' // `undefined` won't ever be used - it is only there because without it ARM deployment fails
   properties: appSettings
 }

--- a/.azure/infra/app-service-config.bicep
+++ b/.azure/infra/app-service-config.bicep
@@ -2,10 +2,9 @@ param appServiceName string
 
 param slotName string
 
-param appSettings object
+param isSlotDeploy bool
 
-// "production" is the name of the "default" slot - essentially it means "no slot"
-var isSlotDeploy = slotName != 'production'
+param appSettings object
 
 resource webAppConfig 'Microsoft.Web/sites/config@2020-12-01' = if(!isSlotDeploy) {
   name: '${appServiceName}/appsettings'

--- a/.azure/infra/app-service-domain.bicep
+++ b/.azure/infra/app-service-domain.bicep
@@ -6,8 +6,6 @@ param appServiceName string
 
 param slotName string
 
-param isSlotDeploy bool
-
 param domainName string
 
 param certName string
@@ -15,6 +13,9 @@ param certName string
 param keyVaultId string
 
 param keyVaultName string
+
+// "production" is the name of the "default" slot - essentially it means "no slot"
+var isSlotDeploy = slotName != 'production'
 
 resource appServiceCertificate 'Microsoft.Web/certificates@2020-12-01' =  {
   name: '${keyVaultName}-${certName}'

--- a/.azure/infra/app-service-domain.bicep
+++ b/.azure/infra/app-service-domain.bicep
@@ -6,6 +6,8 @@ param appServiceName string
 
 param slotName string
 
+param isSlotDeploy bool
+
 param domainName string
 
 param certName string
@@ -13,9 +15,6 @@ param certName string
 param keyVaultId string
 
 param keyVaultName string
-
-// "production" is the name of the "default" slot - essentially it means "no slot"
-var isSlotDeploy = slotName != 'production'
 
 resource appServiceCertificate 'Microsoft.Web/certificates@2020-12-01' =  {
   name: '${keyVaultName}-${certName}'

--- a/.azure/infra/app-service.bicep
+++ b/.azure/infra/app-service.bicep
@@ -12,6 +12,8 @@ param nodeVersion string
 
 param slotName string
 
+param swapSlotName string
+
 // "production" is the name of the "default" slot - essentially it means "no slot"
 var isSlotDeploy = slotName != 'production'
 
@@ -19,6 +21,17 @@ var isSlotDeploy = slotName != 'production'
 var isSharedComputeSku = startsWith(skuName, 'F') || startsWith(skuName, 'D')
 
 var minTlsVersion = '1.2'
+
+var hasSwapSlot = !empty(swapSlotName)
+
+var siteConfig = {
+  http20Enabled: true
+  minTlsVersion: minTlsVersion
+  nodeVersion: nodeVersion
+  // 64 bit and always on not available on anything lower than Basic SKUs
+  use32BitWorkerProcess: isSharedComputeSku
+  alwaysOn: !isSharedComputeSku
+}
 
 // Define the app service plan
 
@@ -46,14 +59,7 @@ resource appService 'Microsoft.Web/sites@2020-12-01' = {
   properties: {
     serverFarmId: appServicePlan.id
     httpsOnly: true
-    siteConfig: {
-      http20Enabled: true
-      minTlsVersion: minTlsVersion
-      nodeVersion: nodeVersion
-      // 64 bit and always on not available on anything lower than Basic SKUs
-      use32BitWorkerProcess: isSharedComputeSku
-      alwaysOn: !isSharedComputeSku
-    }
+    siteConfig: siteConfig
   }
 }
 
@@ -62,18 +68,24 @@ resource appServiceSlot 'Microsoft.Web/sites/slots@2020-12-01' = if(isSlotDeploy
   location: location
   properties: {
     httpsOnly: true
-    siteConfig: {
-      http20Enabled: true
-      minTlsVersion: minTlsVersion
-      nodeVersion: nodeVersion
-      // 64 bit and always on not available on anything lower than Basic SKUs
-      use32BitWorkerProcess: isSharedComputeSku
-      alwaysOn: !isSharedComputeSku
-    }
+    siteConfig: siteConfig
+  }
+}
+
+// The swap slot will auto swap to the target slot
+var swapSlotSiteConfig = union(siteConfig, {
+  autoSwapSlotName: slotName
+})
+
+resource appServiceSwapSlot 'Microsoft.Web/sites/slots@2020-12-01' = if(hasSwapSlot) {
+  name: '${appService.name}/${swapSlotName}'
+  location: location
+  properties: {
+    httpsOnly: true
+    siteConfig: swapSlotSiteConfig
   }
 }
 
 output appServicePlanId string = appServicePlan.id
 output appServiceId string = isSlotDeploy ? appServiceSlot.id : appService.id
 output appServiceDefaultHostname string = isSlotDeploy ? appServiceSlot.properties.defaultHostName : appService.properties.defaultHostName
-output isSlotDeploy bool = isSlotDeploy

--- a/.azure/infra/app-service.bicep
+++ b/.azure/infra/app-service.bicep
@@ -78,7 +78,7 @@ var swapSlotSiteConfig = union(siteConfig, {
 })
 
 resource appServiceSwapSlot 'Microsoft.Web/sites/slots@2020-12-01' = if(hasSwapSlot) {
-  name: '${appService.name}/${swapSlotName}'
+  name: '${appService.name}/${hasSwapSlot ? swapSlotName : 'undefined'}' // `undefined` won't ever be used - it is only there because without it a `What-If` ARM deployment fails
   location: location
   properties: {
     httpsOnly: true

--- a/.azure/infra/app-service.bicep
+++ b/.azure/infra/app-service.bicep
@@ -75,4 +75,5 @@ resource appServiceSlot 'Microsoft.Web/sites/slots@2020-12-01' = if(isSlotDeploy
 
 output appServicePlanId string = appServicePlan.id
 output appServiceId string = isSlotDeploy ? appServiceSlot.id : appService.id
-output appServiceHostname string = isSlotDeploy ? appServiceSlot.properties.defaultHostName : appService.properties.defaultHostName
+output appServiceDefaultHostname string = isSlotDeploy ? appServiceSlot.properties.defaultHostName : appService.properties.defaultHostName
+output isSlotDeploy bool = isSlotDeploy

--- a/.azure/infra/main.bicep
+++ b/.azure/infra/main.bicep
@@ -42,27 +42,11 @@ param webAppNodeVersion object
 
 param webAppSettings object
 
-// This param is currently used to prevent appsettings being updated during "what-if" runs in the build pipeline because it throws an error otherwise
-// Looks like we can remove this once this issue is resolved:
-// https://github.com/Azure/arm-template-whatif/issues/65
-param dryRun bool = false
-
 // Create resource name prefixes for "shared" and "environment" resources
 
 var envResourceGroupName = resourceGroup().name
 var envResourceNamePrefix = toLower('${projectName}-${environment}')
 var sharedResourceNamePrefix = sharedResourceGroupName == envResourceGroupName ? envResourceNamePrefix : toLower('${projectName}')
-
-// Define the key vault resource if required
-
-var keyVaultName = '${envResourceNamePrefix}-kv'
-
-// The only reason to use key vault (currently) is if we are using a custom SSL cert
-var useKeyVault = !empty(webAppCertName)
-
-resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = if(useKeyVault) {
-  name: keyVaultName
-}
 
 // Define the app service resources
 
@@ -84,11 +68,21 @@ module webApp 'app-service.bicep' = {
 
 var webAppServicePlanId = webApp.outputs.appServicePlanId
 var webAppServiceId = webApp.outputs.appServiceId
-var webAppServiceHostname = webApp.outputs.appServiceHostname
+var webAppServiceDefaultHostname = webApp.outputs.appServiceDefaultHostname
+var isWebAppSlotDeploy = webApp.outputs.isSlotDeploy
 
 // Define the app service domain
 
-module webAppDomain 'app-service-domain.bicep' = if(!empty(webAppDomainName)) {
+var hasCustomDomain = !empty(webAppDomainName) && !empty(webAppCertName)
+
+// The only reason to use key vault (currently) is if we are using a custom domain as key vault is used to store the SSL cert
+var keyVaultName = '${envResourceNamePrefix}-kv'
+
+resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = if(hasCustomDomain) {
+  name: keyVaultName
+}
+
+module webAppDomain 'app-service-domain.bicep' = if(hasCustomDomain) {
   name: 'web-app-domain'
   scope: resourceGroup(sharedResourceGroupName)
   params: {
@@ -96,14 +90,15 @@ module webAppDomain 'app-service-domain.bicep' = if(!empty(webAppDomainName)) {
     appServicePlanId: webAppServicePlanId
     appServiceName: webAppName
     slotName: webAppSlotName
+    isSlotDeploy: isWebAppSlotDeploy
     domainName: webAppDomainName
     certName: webAppCertName
-    keyVaultId: useKeyVault ? keyVault.id : ''
-    keyVaultName: useKeyVault ? keyVaultName : ''
+    keyVaultId: hasCustomDomain ? keyVault.id : ''
+    keyVaultName: keyVaultName
   }
 }
 
-var webAppServicePrimaryDomain = empty(webAppDomainName) ? webAppServiceHostname : webAppDomainName
+var webAppServiceHostname = hasCustomDomain ? webAppDomainName : webAppServiceDefaultHostname
 
 // Define the application insights resource
 
@@ -125,13 +120,13 @@ module cdn 'cdn.bicep' = {
   params: {
     location: location
     resourceName: '${envResourceNamePrefix}-cdn'
-    originHostname: webAppServicePrimaryDomain
+    originHostname: webAppServiceHostname
   }
 }
 
 // Define the app service settings - these depend on outputs from other resources so cannot be defined earlier as part of the app service definition
 
-var baseUrl = 'https://${webAppServicePrimaryDomain}'
+var baseUrl = 'https://${webAppServiceHostname}'
 var cdnEndpointHostname = cdn.outputs.endpointHostName
 var cdnEndpointUrl = 'https://${cdnEndpointHostname}'
 
@@ -153,12 +148,13 @@ var webAppDeploymentSettings = {
 // Merge the default settings into any additional settings provided via the `webAppSettings` parameter
 var webAppConfigSettings = union(webAppSettings, webAppDeploymentSettings)
 
-module webAppConfig 'app-service-config.bicep' = if(!dryRun) {
+module webAppConfig 'app-service-config.bicep' = {
   name: 'web-app-config'
   scope: resourceGroup(sharedResourceGroupName)
   params: {
     appServiceName: webAppName
     slotName: webAppSlotName
+    isSlotDeploy: isWebAppSlotDeploy
     appSettings: webAppConfigSettings
   }
 }

--- a/.azure/infra/main.bicep
+++ b/.azure/infra/main.bicep
@@ -34,6 +34,8 @@ param webAppSkuCapacity int
 
 param webAppSlotName string
 
+param webAppSwapSlotName string
+
 param webAppDomainName string
 
 param webAppCertName string
@@ -63,13 +65,13 @@ module webApp 'app-service.bicep' = {
     skuCapacity: webAppSkuCapacity
     nodeVersion: webAppNodeVersion.node
     slotName: webAppSlotName
+    swapSlotName: webAppSwapSlotName
   }
 }
 
 var webAppServicePlanId = webApp.outputs.appServicePlanId
 var webAppServiceId = webApp.outputs.appServiceId
 var webAppServiceDefaultHostname = webApp.outputs.appServiceDefaultHostname
-var isWebAppSlotDeploy = webApp.outputs.isSlotDeploy
 
 // Define the app service domain
 
@@ -90,7 +92,6 @@ module webAppDomain 'app-service-domain.bicep' = if(hasCustomDomain) {
     appServicePlanId: webAppServicePlanId
     appServiceName: webAppName
     slotName: webAppSlotName
-    isSlotDeploy: isWebAppSlotDeploy
     domainName: webAppDomainName
     certName: webAppCertName
     keyVaultId: hasCustomDomain ? keyVault.id : ''
@@ -154,7 +155,7 @@ module webAppConfig 'app-service-config.bicep' = {
   params: {
     appServiceName: webAppName
     slotName: webAppSlotName
-    isSlotDeploy: isWebAppSlotDeploy
+    swapSlotName: webAppSwapSlotName
     appSettings: webAppConfigSettings
   }
 }

--- a/.azure/infra/main.parameters.json.template
+++ b/.azure/infra/main.parameters.json.template
@@ -23,6 +23,9 @@
     "webAppSlotName": {
       "value": "{{webAppSlotName}}"
     },
+    "webAppSwapSlotName": {
+      "value": "{{webAppSwapSlotName}}"
+    },
     "webAppDomainName": {
       "value": "{{webAppDomainName}}"
     },


### PR DESCRIPTION
Goal is to support deploying into a pre-prod slot so the app can be warmed up before it is auto-swapped with production.